### PR TITLE
Change file read mode to 'rb' to avoid encoding errors.

### DIFF
--- a/strip_tags/cli.py
+++ b/strip_tags/cli.py
@@ -13,7 +13,7 @@ from strip_tags import strip_tags
     multiple=True,
     help="Remove content in these selectors",
 )
-@click.option("-i", "--input", type=click.File("r"), default="-", help="Input file")
+@click.option("-i", "--input", type=click.File("rb"), default="-", help="Input file")
 @click.option("-m", "--minify", is_flag=True, help="Minify whitespace")
 @click.option("keep_tags", "-t", "--keep-tag", multiple=True, help="Keep these <tags>")
 @click.option("--all-attrs", is_flag=True, help="Include all attributes on kept tags")

--- a/tests/test_strip_tags.py
+++ b/tests/test_strip_tags.py
@@ -79,3 +79,13 @@ def test_strip_lib(input, args, expected):
         all_attrs=all_attrs,
     )
     assert result == expected
+
+
+def test_not_ut8_encoding():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open("input.html", "wb") as fp:
+            fp.write("<h1>hello</h1>".encode("utf-16"))
+        result = runner.invoke(cli, ["-i", "input.html"])
+    assert result.exit_code == 0
+    assert result.output == "hello\n"


### PR DESCRIPTION
Fixes #7  by using binary read mode `rb` when using `click.File()`, which allows BeautifulSoup to automatically handle different encodings.  I believe, by default, using `r` converts to a string using `utf-8` which could cause issues with international characters.